### PR TITLE
Change SteamVR default settings to prevent them from getting overwritten on initial import

### DIFF
--- a/Assets/Actions/Scripts/SeatedPositionResetAction.cs
+++ b/Assets/Actions/Scripts/SeatedPositionResetAction.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using UnityEngine;
+using Valve.VR;
 
 namespace EVRC.Core.Actions
 {
@@ -32,7 +33,7 @@ namespace EVRC.Core.Actions
         {
             yield return new WaitForSeconds(holdForSeconds);
             Debug.Log("Resetting seated position");
-            // OpenVR.System.ResetSeatedZeroPose();
+            OpenVR.Chaperone.ResetZeroPose(SteamVR.settings.trackingSpace);
         }
     }
 }

--- a/Assets/Core/Assets/GameState/Elite Dangerous State.asset
+++ b/Assets/Core/Assets/GameState/Elite Dangerous State.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 02dc692eea0eb8e4aa9506ebd427e1b4, type: 3}
   m_Name: Elite Dangerous State
   m_EditorClassIdentifier: 
-  gameEvent: {fileID: 0}
+  gameEvent: {fileID: 11400000, guid: 1e32b9862c3503c4db55b246757a21f7, type: 2}
   running: 0
   processId: 0
   processName: 

--- a/Assets/Core/Scripts/CockpitUIMode.cs
+++ b/Assets/Core/Scripts/CockpitUIMode.cs
@@ -70,7 +70,7 @@ namespace EVRC.Core
 
         void OnEnable()
         {
-            // EDStateManager.eliteDangerousStarted.Listen(OnGameStartedOrStopped);
+            EDStateManager.EliteDangerousStarted.Listen(OnGameStartedOrStopped);
             EDStateManager.EliteDangerousStopped.Listen(OnGameStartedOrStopped);
             EDStateManager.GuiFocusChanged.Listen(OnGuiFocusChanged);
             EDStateManager.FlagsChanged.Listen(OnFlagsChanged);
@@ -79,7 +79,7 @@ namespace EVRC.Core
 
         void OnDisable()
         {
-            // EDStateManager.eliteDangerousStarted.Remove(OnGameStartedOrStopped);
+            EDStateManager.EliteDangerousStarted.Remove(OnGameStartedOrStopped);
             EDStateManager.EliteDangerousStopped.Remove(OnGameStartedOrStopped);
             EDStateManager.GuiFocusChanged.Remove(OnGuiFocusChanged);
             EDStateManager.FlagsChanged.Remove(OnFlagsChanged);

--- a/Assets/Core/Scripts/EDStateManager.cs
+++ b/Assets/Core/Scripts/EDStateManager.cs
@@ -27,6 +27,7 @@ namespace EVRC.Core
         public GameEvent eliteDangerousStarted;
         // Replace these Steam Events with GameEvents
         public static Events.Event EliteDangerousStopped = new Events.Event();
+        public static Events.Event EliteDangerousStarted = new Events.Event();
         public static Events.Event<uint, string> CurrentProcessChanged = new Events.Event<uint, string>();
         public static Events.Event<EDGuiFocus> GuiFocusChanged = new Events.Event<EDGuiFocus>();
         public static Events.Event<EDStatusFlags> FlagsChanged = new Events.Event<EDStatusFlags>();
@@ -116,7 +117,7 @@ namespace EVRC.Core
 
         internal void SetIsEliteDangerousRunning(bool running)
         {
-            if (eliteDangerousState.running == running) return;
+            //if (eliteDangerousState.running == running) return;
             eliteDangerousState.running = running;
             eliteDangerousState.processId = currentProcessId;
             eliteDangerousState.processName = currentProcessName;
@@ -125,6 +126,7 @@ namespace EVRC.Core
             {
                 StartCoroutine(WatchStatusFile());
                 eliteDangerousStarted.Raise();
+                EliteDangerousStarted.Send();
             }
             else
             {

--- a/Assets/Core/Scripts/GameFocusVisibility.cs
+++ b/Assets/Core/Scripts/GameFocusVisibility.cs
@@ -20,6 +20,7 @@ namespace EVRC.Core
             windowFocusManager.eliteDangerousState = eliteDangerousState;
 
             EDStateManager.EliteDangerousStopped.Listen(OnGameStartedOrStopped);
+            EDStateManager.EliteDangerousStarted.Listen(OnGameStartedOrStopped);
             WindowFocusManager.ForegroundWindowProcessChanged.Listen(OnForegroundWindowProcessChanged);
 
             Refresh();
@@ -28,6 +29,7 @@ namespace EVRC.Core
         void OnDisable()
         {
             EDStateManager.EliteDangerousStopped.Remove(OnGameStartedOrStopped);
+            EDStateManager.EliteDangerousStarted.Remove(OnGameStartedOrStopped);
             WindowFocusManager.ForegroundWindowProcessChanged.Remove(OnForegroundWindowProcessChanged);
         }
 

--- a/Assets/Scenes/EVRC.unity
+++ b/Assets/Scenes/EVRC.unity
@@ -204,8 +204,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: af22bd791bcd75f4b9078393c57c4c5e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  controlBindingsState: {fileID: 11400000, guid: 1de2906d06cd6f745bab03c953c45a3a,
-    type: 2}
 --- !u!114 &59438901
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1116,6 +1114,52 @@ Transform:
   m_Father: {fileID: 1074601785}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &516072241 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 9098288760151393727, guid: 13dfd2ff77290bb4faf75012641f360d,
+    type: 3}
+  m_PrefabInstance: {fileID: 1749688776}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &516072243 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5625217958891209880, guid: 13dfd2ff77290bb4faf75012641f360d,
+    type: 3}
+  m_PrefabInstance: {fileID: 1749688776}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 516072241}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf32f9d7c93175745bcf1ee89d900bc9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &516072244
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 516072241}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f1ef366d1adba714aa9442631db4e0b7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Source: {fileID: 11400000, guid: 1e32b9862c3503c4db55b246757a21f7, type: 2}
+  Response:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 516072243}
+        m_TargetAssemblyTypeName: EVRC.Desktop.StatusView, EVRC.Desktop
+        m_MethodName: Refresh
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &569466639
 GameObject:
   m_ObjectHideFlags: 0
@@ -2658,6 +2702,11 @@ PrefabInstance:
     - target: {fileID: 4811742776677330, guid: 71fe574d30e93584e986026484e39e7f, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 114168438288787448, guid: 71fe574d30e93584e986026484e39e7f,
+        type: 3}
+      propertyPath: deadzonePercentage
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 114532849731444944, guid: 71fe574d30e93584e986026484e39e7f,
         type: 3}

--- a/Assets/SteamVR/Scripts/SteamVR_Settings.cs
+++ b/Assets/SteamVR/Scripts/SteamVR_Settings.cs
@@ -39,7 +39,7 @@ namespace Valve.VR
 
         [SerializeField]
         [FormerlySerializedAsAttribute("trackingSpace")]
-        private ETrackingUniverseOrigin trackingSpaceOrigin = ETrackingUniverseOrigin.TrackingUniverseStanding;
+        private ETrackingUniverseOrigin trackingSpaceOrigin = ETrackingUniverseOrigin.TrackingUniverseSeated;
 
         [Tooltip("Filename local to StreamingAssets/SteamVR/ folder")]
         public string actionsFilePath = "actions.json";
@@ -60,16 +60,16 @@ namespace Valve.VR
 
         [Space()]
         [Tooltip("This determines if we use legacy mixed reality mode (3rd controller/tracker device connected) or the new input system mode (pose / input source)")]
-        public bool legacyMixedRealityCamera = true;
+        public bool legacyMixedRealityCamera = false;
 
         [Tooltip("[NON-LEGACY] This is the pose action that will be used for positioning a mixed reality camera if connected")]
-        public SteamVR_Action_Pose mixedRealityCameraPose = SteamVR_Input.GetPoseAction("ExternalCamera");
+        public SteamVR_Action_Pose mixedRealityCameraPose = SteamVR_Input.GetPoseAction("Pose");
 
         [Tooltip("[NON-LEGACY] This is the input source to check on the pose for the mixed reality camera")]
-        public SteamVR_Input_Sources mixedRealityCameraInputSource = SteamVR_Input_Sources.Camera;
+        public SteamVR_Input_Sources mixedRealityCameraInputSource = SteamVR_Input_Sources.Head;
 
         [Tooltip("[NON-LEGACY] Auto enable mixed reality action set if file exists")]
-        public bool mixedRealityActionSetAutoEnable = true;
+        public bool mixedRealityActionSetAutoEnable = false;
 
         [Tooltip("[EDITOR ONLY] The (left) prefab to be used for showing previews while posing hands")]
         public GameObject previewHandLeft;

--- a/Assets/SteamVR_Resources/Resources/SteamVR_Settings.asset
+++ b/Assets/SteamVR_Resources/Resources/SteamVR_Settings.asset
@@ -28,7 +28,5 @@ MonoBehaviour:
     needsReinit: 0
   mixedRealityCameraInputSource: 9
   mixedRealityActionSetAutoEnable: 0
-  previewHandLeft: {fileID: 1000013348574242, guid: 638779290bce1af49b356f33dcc6fccf,
-    type: 3}
-  previewHandRight: {fileID: 1000010304998954, guid: 6def53d002137b747aec0b29551e0e25,
-    type: 3}
+  previewHandLeft: {fileID: 0}
+  previewHandRight: {fileID: 0}

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -135,7 +135,8 @@ PlayerSettings:
     16:9: 1
     Others: 1
   bundleVersion: .8
-  preloadedAssets: []
+  preloadedAssets:
+  - {fileID: -8947760093551166720, guid: 5a4599796d93a8949bb8d40ecedf8c44, type: 2}
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1


### PR DESCRIPTION
Spent wayyy too much time trying to debug why the tracking universe was messed up, only to find out the SteamVR plugin overwrites the settings when opening the project for the first time

https://github.com/ValveSoftware/steamvr_unity_plugin/pull/974